### PR TITLE
Add support for networks.

### DIFF
--- a/builders/mkMinecraftServer.nix
+++ b/builders/mkMinecraftServer.nix
@@ -8,12 +8,13 @@
 }: {
   name ? "",
   src ? null,
+  serverLocation ? null,
   hash ? "",
   meta ? {},
   ...
 }:
 mkGenericServer {
-  inherit name src hash;
+  inherit name src serverLocation hash;
 
   nativeBuildInputs = [
     mcman
@@ -26,14 +27,18 @@ mkGenericServer {
     jre
     jre8
   ];
-
-  buildPhase = ''
-    HOME=$TMPDIR
-    CI=true # Better build logs
-
-    cd $src
-    mcman build -o $out
-  '';
+  buildPhase =
+    ''
+      HOME=$TMPDIR
+      CI=true # Better build logs
+      cd $src
+    ''
+    + lib.optionalString (serverLocation != null) ''
+      cd ${serverLocation}
+    ''
+    + ''
+      mcman build -o $out
+    '';
 
   startCmd = "./start.sh";
 


### PR DESCRIPTION
## Description of changes

I added a `serverLocation` argument. I use it like this:

```nix
      lobby = {
        package = pkgs.mkMinecraftServer {
          name = "lobby";
          src = ./network; # Path to a mcman config
          serverLocation = "servers/lobby";
          hash = "sha256-6sKOI/N1WW7JKZ+NnvH2u6rzqC2N5GYDYJpR4OwMsVc="; #"";
        };
        proxy.enable = false;
      };
```

It feels kinda hacky, so don't merge it right now, I want to see if we can improve it. If you have any ideas, go ahead.

## Relevant Issues

<!-- Eg. #43 -->

## CC Maintainers

@IogaMaster 

