### PR TITLE
Make java version explicit instead of implicit

### DIFF
--- a/builders/mkMinecraftServer.nix
+++ b/builders/mkMinecraftServer.nix
@@ -3,7 +3,6 @@
   mkGenericServer,
   mcman,
   jre,
-  jre8,
   ...
 }: {
   name ? "",
@@ -11,6 +10,7 @@
   serverLocation ? null,
   hash ? "",
   meta ? {},
+  java ? jre,
   ...
 }:
 mkGenericServer {
@@ -18,14 +18,12 @@ mkGenericServer {
 
   nativeBuildInputs = [
     mcman
-    jre
-    jre8
+    java
   ];
 
   buildInputs = [
     mcman
-    jre
-    jre8
+    java
   ];
   buildPhase =
     ''


### PR DESCRIPTION
## Description of changes

<!-- What changes did you make -->

Made it so only one java runtime is available at all times.

## Relevant Issues
Not listed on Github. Couldn't be arsed to make an issue when I could put up a fix instead.

Basically old forge will refuse to work. Now it doesn't. Relying on UB is le bad
<!-- Eg. #43 -->

## CC Maintainers

<!-- Most of the time it will be IogaMaster -->

